### PR TITLE
enhanced reactor fluid boxes

### DIFF
--- a/Nucular/prototypes/reactor-entity.lua
+++ b/Nucular/prototypes/reactor-entity.lua
@@ -77,14 +77,28 @@ data:extend(
           pipe_covers = pipecoverspictures(),
           base_area = 10,
           base_level = -1,
-          pipe_connections = {{ type="input", position = {-2, 1} },{ type="input", position = {-1, 2} }}
+          pipe_connections = {{ type="input", position = {-1, -2} }}
+        },
+        {
+          production_type = "input",
+          pipe_covers = pipecoverspictures(),
+          base_area = 10,
+          base_level = -1,
+          pipe_connections = {{ type="input", position = {1, -2} }}
         },
         {
           production_type = "output",
           pipe_covers = pipecoverspictures(),
           base_level = 1,
-          pipe_connections = {{ position = {2, 1} },{ position = {1, 2}  }}
-        }
+          pipe_connections = {{ position = {-1, 2} }}
+        },
+        {
+          production_type = "output",
+          pipe_covers = pipecoverspictures(),
+          base_level = 1,
+          pipe_connections = {{ position = {1, 2} }}
+        },
+      off_when_no_fluid_recipe = true
       }
     }
   })


### PR DESCRIPTION
- added fluid boxes to all corners
- turn off fluid connectors for breeder

A little change to the reactors allowing more versatile plumbing. While at it I removed the fluid box arrows when reactors are used as breeder.
